### PR TITLE
:memo: Add initial rockspec and github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on: [ push, pull_request ]
+
+jobs:
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        lua_version: [ "5.4", "5.3", "5.2", "5.1", 'luajit-2.0', 'luajit-2.1' ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Lua
+        uses: luarocks/gh-actions-lua@master
+        with:
+          luaVersion: ${{ matrix.lua_version }}
+
+      - name: Set up LuaRocks
+        uses: luarocks/gh-actions-luarocks@master
+
+      - name: Setup ‘luarocks’
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Setup dependencies
+        run: luarocks install busted
+
+      - name: Build luarock
+        run: luarocks build
+
+      - name: Run regression tests
+        # disable project-local path prefixes to force use of system installation
+        run: luarocks test

--- a/string_lambda-scm-1.rockspec
+++ b/string_lambda-scm-1.rockspec
@@ -1,0 +1,41 @@
+rockspec_format = '3.0'
+package = 'string_lambda'
+version = 'scm-1'
+
+source = {
+  url = 'git+https://github.com/cmotl/lua-string_lambda',
+  branch = 'main', -- this will be replaced by the release workflow
+}
+
+description = {
+  summary = 'Wrapper around pl.utils.string_lambda for ease of use',
+  detailed = [[
+    The library provides a simple wrapper around `pl.utils.string_lambda`
+    for easier use.
+  ]],
+  license = 'MIT',
+  homepage = 'https://github.com/cmotl/lua-string_lambda',
+  issues_url = 'https://github.com/cmotl/lua-string_lambda/issues',
+  maintainer = 'Christopher Motl',
+}
+
+dependencies = {
+  'lua >= 5.1, <= 5.4',
+  'penlight = 1.14.0',
+}
+
+test_dependencies = {
+  'busted',
+}
+
+build = {
+  type = 'builtin',
+  modules = {
+    string_lambda = 'lib/string_lambda.lua',
+  },
+}
+
+test = {
+  type = 'busted',
+  flags = '--verbose',
+}


### PR DESCRIPTION
Problem:
- No rockspec exists for building the releasable package.
- No automated tests are being run on pull requests.

Solution:
- Add initial rockspec.
- Add initial github actions workflow.